### PR TITLE
Scratch remote sensor protocol's sensor-update can send strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ class ScratchReceiver(object):
   def broadcast_handler(message):
     print('[receive] broadcast:', message)
   @staticmethod
-  def sonsor_update_handler(**sensor_data):
+  def sensor_update_handler(**sensor_data):
     for name, value in sensor_data.items():
       print('[receive] sensor-update:', name, value)
-rsc = scratch.RemoteSensorConnection(ScratchReceiver.broadcast_handler, ScratchReceiver.sonsor_update_handler)  
+rsc = scratch.RemoteSensorConnection(ScratchReceiver.broadcast_handler, ScratchReceiver.sensor_update_handler)  
 rsc.connect()  
 rsc.send_broadcast('connected')  
-rsc.send_sensor_update(test_sonsor=100)  
+rsc.send_sensor_update(test_sensor=100)  
 rsc.disconnect()  
 ```
 

--- a/scratch/scratch.py
+++ b/scratch/scratch.py
@@ -228,7 +228,7 @@ class RemoteSensorConnection(object):
         message = 'sensor-update '
         for name, value in sensor_data.items():
             if not (isinstance(value, int) or isinstance(value, float) or isinstance(value, str)):
-                raise ValueError('sensor-value must be int, fload, or str')
+                raise ValueError('sensor-value must be int, float, or str')
             message += '"' + name + '" ' + str(value) + ' '
         message_data = message.encode('utf-8')
         try:

--- a/scratch/scratch.py
+++ b/scratch/scratch.py
@@ -214,7 +214,7 @@ class RemoteSensorConnection(object):
 
         sensor-updateメッセージの送信を行います。
         センサー名として日本語を含むutf-8文字の送信が可能ですが、Scratch側で先にメッセージとして登録していないとScratch側で文字化けします。
-        センサー値は数値(int/float)である必要があります。
+        センサー値は数値(int/float)または文字列(str)である必要があります。
 
         Args:
             **sensor_data: sensor-updateとして送信する、センサー名とセンサー値を、センサー名=センサー値で並べる。任意の数可能
@@ -227,8 +227,8 @@ class RemoteSensorConnection(object):
         '''
         message = 'sensor-update '
         for name, value in sensor_data.items():
-            if not (isinstance(value, int) or isinstance(value, float)):
-                raise ValueError('sensor-value must be str')
+            if not (isinstance(value, int) or isinstance(value, float) or isinstance(value, str)):
+                raise ValueError('sensor-value must be int, fload, or str')
             message += '"' + name + '" ' + str(value) + ' '
         message_data = message.encode('utf-8')
         try:


### PR DESCRIPTION
Scratch remote sensor protocol's sensor-update can send strings.
See https://wiki.scratch.mit.edu/wiki/Remote_Sensors_Protocol .
So fix that send_sensor_update() can send strings.
